### PR TITLE
fix: move AppersonAuto local dev port to 7779 (avoid CL clash)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-PORT=7777
+PORT=7779
 NODE_ENV=development
 BackendUrl=http://localhost:7000
 GoogleClientId=

--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@
 <https://www.appersonautomotive.com/>
 
 We use Heroku to host this website, which is a static React frontend that runs on a node server.js (Express.js) server. There is a Procfile that tells Heroku to run the server.js file and both of these files are needed so please do NOT delete them.
+
+## Local development
+
+```bash
+npm install
+npm run dev
+```
+
+The Vite dev server runs on **port 7779** (set via `PORT` in `.env` / `.env.example`). It was moved off the previous default of `7777` so AppersonAuto no longer clashes with CollegeLutheran — every WebJamApps frontend and backend can run at the same time. Current local port map: web-jam-back `7000`, WebJamSocketCluster `8000`, JaMmusic `7878`, CollegeLutheran `7777`, AppersonAuto `7779`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appersonautomotive.com",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "appersonautomotive.com",
   "main": "dist/index.html",
   "repository": {


### PR DESCRIPTION
AppersonAuto and CollegeLutheran both defaulted to port **7777**, so they couldn't run locally at the same time. Moves AppersonAuto to **7779**.

- `PORT=7779` in `.env.example` (and the gitignored local `.env`)
- README "Local development" section with the full WebJamApps local port map
- Patch bump 3.0.0 → 3.0.1

Pairs with web-jam-tools PR #34 (the "Start All Apps" workspace tasks). Draft — Josh tests + merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)