### PR TITLE
chore: update .env.example BUILD_BRANCH master->main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,5 @@ GoogleClientId=
 AuthProductionBaseURL=https:/web-jam-back-dev.herokuapp.com
 userRoles={"roles" : ["Rolename1", "Rolename2"]}
 AllowUrl={"urls": ["http://something.com", "https://something.com", "http://localhost:7000", "http://localhost:9000"]}
-BUILD_BRANCH=master
+BUILD_BRANCH=main
 HashString=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "appersonautomotive.com",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "appersonautomotive.com",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appersonautomotive.com",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "appersonautomotive.com",
   "main": "dist/index.html",
   "repository": {


### PR DESCRIPTION
## What
Updates the `BUILD_BRANCH` template default in `.env.example` from `master` to `main`, reflecting today's `master` → `main` branch rename (Task 7 standardization to `dev` + `main`).

`BUILD_BRANCH` appears only in `.env.example` — it is not read by any committed code (grep-verified), so this is a cosmetic/template-consistency change. Patch version bump 3.0.1 → 3.0.2.

## How to Test Locally
```bash
git checkout fix-env-build-branch-main
grep BUILD_BRANCH .env.example   # => BUILD_BRANCH=main
npm install
npm run typecheck && npm test
```
No runtime behavior changes; CI (`.circleci/config.yml`) runs on all branches and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)