### PR TITLE
AGENTS.md: branch & memory hygiene — never push to merged branches; lessons ship inside the PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md — AppersonAuto
+
+Guidance for AI coding agents (agy/Antigravity, etc.) working in this repo.
+
+## What this is
+A React + TypeScript + Vite front-end for Apperson Auto.
+
+## Commands (get green before declaring done)
+- `npm test` — the gate: stylelint + eslint + typecheck + unit tests.
+- `npm run test:lint` / `npm run typecheck` for quicker partial checks.
+
+## Workflow
+- Always work on a feature branch off the latest `dev`. Never merge to `dev` or
+  `main` — Josh is the mandatory human reviewer.
+- Open PRs with the shared script
+  (`~/WebJamApps/web-jam-tools/scripts/create-draft-pr.sh`), never
+  `gh pr create` directly. It opens a **draft** PR based on **`dev`**.
+- Bump the semver `version` in `package.json` **once per PR** on the feature
+  branch (not once per push).
+- Do not add, upgrade, or remove dependencies — ask first.
+
+## Branch & memory hygiene
+- One branch per task: never create or push any branch other than the one
+  created for the current task.
+- Once your PR is merged or closed, its branch is DEAD — never commit to it or
+  push it again. Follow-up work (including afterthoughts like docs or lessons
+  learned) starts on a NEW branch off the latest `dev`, with its own PR.
+- Save lessons BEFORE the merge, not after: anything you learned during the task
+  worth keeping (build quirks, selector gotchas, testing patterns — e.g. the
+  output of a `/learn`-style memory pass) gets committed to this file's Memory
+  section on the SAME task branch while the PR is still open, so it ships inside
+  the PR. A post-merge push to the old branch strands the lesson and forces
+  manual cleanup.
+
+## Memory
+(Add lessons learned here, one bullet each.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appersonautomotive.com",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "appersonautomotive.com",
   "main": "dist/index.html",
   "repository": {


### PR DESCRIPTION
## Summary
Creates a minimal AGENTS.md (repo had none) with the shared workflow rules plus the new 'Branch & memory hygiene' section: one branch per task; a merged/closed PR's branch is dead; lessons learned ship inside the open PR, never as a post-merge push. Same rule landed in JaMmusic (#1178) and CollegeLutheran (#769). Docs-only; version 3.0.6.

Closes #215

## How to test locally
Docs-only (new AGENTS.md + version bump) — no runtime surface. Review the rendered file; confirm no src/test changes: git diff dev --stat

## Test evidence
git diff dev --stat: AGENTS.md new file (+36 lines), package.json version 3.0.5→3.0.6 only. No code touched, so lint/unit gates unaffected.

🤖 Work by Claude Code — Fable 5