### PR TITLE
docs(agents): PR body conventions — bullets, real evidence, exact model attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,12 @@ A React + TypeScript + Vite front-end for Apperson Auto.
 
 ## Memory
 (Add lessons learned here, one bullet each.)
+
+## Pull requests
+
+### PR body conventions (violations may be machine-rejected)
+
+- **Summary**: markdown bullet points, one change per bullet — never a run-on paragraph.
+- **Test evidence**: paste the REAL runner output verbatim (the lines showing pass/fail and test counts), inside a ``` fence — never a description like "all tests passed". If the output has scrolled out of view, re-run the test command and paste what it prints.
+- **Test plan**: exact commands and manual steps that exercise the change (start command, route/page, what to click, expected visible result) — a green test suite alone is not a plan.
+- **Attribution**: `--author` names the model actually doing the work. Antigravity/agy sessions are ALWAYS `Antigravity — Gemini 3.5 Flash (Medium)` or `(High)` — never write any other Gemini model name (models misremember their own identity; use this exact string).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appersonautomotive.com",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "appersonautomotive.com",
   "main": "dist/index.html",
   "repository": {


### PR DESCRIPTION
## Summary
- Add PR body conventions subsection to AGENTS.md (bulleted summary, verbatim fenced test evidence, test-plan substance, exact agy model attribution) so interactive agy runs see the same PR rules the headless wrapper injects
- Patch version bump

## How to test locally
Docs-only change. Review the rendered AGENTS.md section on the branch:
```sh
git show HEAD -- AGENTS.md
```
Expect: the new '### PR body conventions' subsection under '## Pull requests'.

## Test evidence
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,12 @@ A React + TypeScript + Vite front-end for Apperson Auto.
 
 ## Memory
 (Add lessons learned here, one bullet each.)
+
+## Pull requests
+
+### PR body conventions (violations may be machine-rejected)
+
+- **Summary**: markdown bullet points, one change per bullet — never a run-on paragraph.
+- **Test evidence**: paste the REAL runner output verbatim (the lines showing pass/fail and test counts), inside a ``` fence — never a description like "all tests passed". If the output has scrolled out of view, re-run the test command and paste what it prints.
+- **Test plan**: exact commands and manual steps that exercise the change (start command, route/page, what to click, expected visible result) — a green test suite alone is not a plan.
+- **Attribution**: `--author` names the model actually doing the work. Antigravity/agy sessions are ALWAYS `Antigravity — Gemini 3.5 Flash (Medium)` or `(High)` — never write any other Gemini model name (models misremember their own identity; use this exact string).

🤖 Work by Claude Code — Haiku 4.5